### PR TITLE
Deshabilitar boton de edición para ventas

### DIFF
--- a/src/mis-ventas/mis-ventas.jsx
+++ b/src/mis-ventas/mis-ventas.jsx
@@ -308,7 +308,7 @@ export default class MisVentas extends React.Component {
                   <CollapsibleItem key={empSale.ventaId}
                     header={this.getSalesHeader(empSale)}>
                       {empSale.form.isReadMode ? <SalesForm {...empSale} inventario={this.state.inventario}>
-                          <Button onClick={(e) => {e.preventDefault();this.toggleEditMode(saleIndex)}}>Editar</Button>                        
+                          <Button disabled="true" onClick={(e) => {e.preventDefault();this.toggleEditMode(saleIndex)}}>Editar</Button>                        
                       </SalesForm> :
                       this.state.inventario && <SalesForm {...this.state.updatingSaleForm}
                         setFormField={(newFieldValue) => this.updateFromState(newFieldValue)}


### PR DESCRIPTION
We got the requirement of disabling Edit button for sales module while we investigate the root cause of the errors in the module.
![Captura de pantalla 2024-10-18 a la(s) 8 45 56 p m](https://github.com/user-attachments/assets/5d569db6-7f8a-4fb2-9f7d-d7511eba6b38)
